### PR TITLE
Added TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "lts/*"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "storefront",
+  "version": "1.0.0",
+  "description": "This is the readme file for StoreFront. Our new app!",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/powernerd/storefront.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/powernerd/storefront/issues"
+  },
+  "homepage": "https://github.com/powernerd/storefront#readme"
+}


### PR DESCRIPTION
I created a quick and dirty [TravisCI](https://travis-ci.org/) integration here. TravisCI builds will continue to fail until we update the package.json with our test framework and write a unit test. We shouldn't merge this pull request until it's working and the builds are passing.

**TO DO:**
1. Install and configure [tap](https://www.npmjs.com/package/tap) or [mocha](https://www.npmjs.com/package/mocha) and [should](https://www.npmjs.com/package/should) or [chai](https://www.npmjs.com/package/chai).
1. Write a unit test.
1. Make sure the package.json is set up with a "test" script which will run the test framework as TravisCI runs `npm test`.